### PR TITLE
fix(core): correct docs directory path in release-docs workflow

### DIFF
--- a/.github/workflows/release-docs.yml
+++ b/.github/workflows/release-docs.yml
@@ -29,7 +29,7 @@ jobs:
 
       - name: 'Install dependencies and build'
         run: |
-          cd apps/docs
+          cd /docs
           pnpm install
           pnpm run build
 

--- a/.github/workflows/release-docs.yml
+++ b/.github/workflows/release-docs.yml
@@ -29,7 +29,7 @@ jobs:
 
       - name: 'Install dependencies and build'
         run: |
-          cd /docs
+          cd docs
           pnpm install
           pnpm run build
 
@@ -48,7 +48,7 @@ jobs:
           # Enable dotglob to copy hidden files (like .gitignore)
           shopt -s dotglob
           # Copy the build from the docs-docusaurus/build folder
-          cp -r apps/docs/build/* /tmp/temp-directory/
+          cp -r docs/build/* /tmp/temp-directory/
           shopt -u dotglob
           # Stash any changes to prevent checkout conflicts
           git stash push


### PR DESCRIPTION
## Description

### What does this PR do?

This PR fixes the incorrect documentation directory path used in the `release-docs` workflow.

### Changes included

* Updated workflow path from:

```txt id="’wini2c8"
app/docs
```

to:

```txt id="’wini3c8"
docs
```

to match the current project structure.

### Type of Change

* [x] 🐛 Bug fix
* [ ] 🚀 New feature
* [ ] 📄 Documentation update
* [ ] ⚙️ Code refactoring
* [x] 🔧 Configuration or CI/CD change
* [ ] 🧹 Maintenance or dependency update

---

## Additional Context

This fix ensures the GitHub Actions workflow correctly locates and builds the documentation project during deployment.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Tooling / config / CI changes
- Corrected documentation directory path in `release-docs` GitHub Actions workflow from `apps/docs` to `docs` to align with current project structure
- Ensures the release-docs pipeline can properly locate and build Docusaurus documentation during deployment

## Breaking changes
None

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/mindfiredigital/ignix-lite/pull/80)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->