### PR TITLE
fix(release): resolve workspace dependency protocol at publish time

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -58,7 +58,7 @@ jobs:
           commit: "chore(release): version packages"
           title: "chore(release): version packages"
           version: node .github/changeset-version.mjs
-          publish: pnpm release
+          publish: pnpm -r publish --no-git-checks
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           NPM_TOKEN: ${{ secrets.NPM_TOKEN }}


### PR DESCRIPTION
### **PR Title**
`fix(release): resolve workspace dependency protocol at publish time`

---

### **PR Description**

#### **What does this PR do?**
Updates the release workflow in `.github/workflows/release.yml` to use `pnpm -r publish --no-git-checks` during the publishing phase. This ensures `pnpm` natively translates all `"workspace:*"` dependency references into real published package version numbers on the npm registry.

#### **Type of Change**
- [x] 🔧 Configuration or CI/CD change

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

### Tooling / Config / CI changes
- Added `.github/workflows/release.yml` GitHub Actions workflow with `publish: pnpm -r publish --no-git-checks` command to enable pnpm to natively resolve all `workspace:*` dependency references to concrete published package versions at publish time

### Breaking changes
None

<!-- end of auto-generated comment: release notes by coderabbit.ai -->