### PR TITLE
fix(mcp): fix the release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -58,7 +58,7 @@ jobs:
           commit: "chore(release): version packages"
           title: "chore(release): version packages"
           version: node .github/changeset-version.mjs
-          publish: pnpm -r publish --no-git-checks
+          publish: pnpm changeset publish
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           NPM_TOKEN: ${{ secrets.NPM_TOKEN }}


### PR DESCRIPTION
PR Title
fix(release): resolve workspace dependency protocol at publish time

PR Description
What does this PR do?
Updates the release workflow in .github/workflows/release.yml to use pnpm changeset publish during the publishing phase. This ensures pnpm natively translates all "workspace:*" dependency references into real published package version numbers on the npm registry.