### PR TITLE
fix(mcp,engine): resolve filesystem launch crash and copy api-full.txt

### DIFF
--- a/packages/engine/package.json
+++ b/packages/engine/package.json
@@ -12,9 +12,9 @@
         }
     },
     "scripts": {
-        "build": "tsup && copyfiles -u 2 src/manifests/*.json dist/manifests && pnpm build:index",
+        "build": "tsup && copyfiles -u 2 src/manifests/*.json dist/manifests && copyfiles -f ../../api-full.txt dist && pnpm build:index",
         "build:index": "tsx src/tools/build-index.ts",
-        "dev": "tsup --watch --onSuccess \"copyfiles -u 2 src/manifests/*.json dist/manifests && pnpm build:index\""
+        "dev": "tsup --watch --onSuccess \"copyfiles -u 2 src/manifests/*.json dist/manifests && copyfiles -f ../../api-full.txt dist && pnpm build:index\""
     },
     "dependencies": {
         "emmet": "^2.4.11",

--- a/packages/engine/src/utils/intent-parser.ts
+++ b/packages/engine/src/utils/intent-parser.ts
@@ -68,18 +68,20 @@ function parseIntents(raw: string): IntentEntry[] {
   return entries
 }
 
-// ---- Resolve the api-full.txt path relative to this package root ----
 function loadIntents(): IntentEntry[] {
   try {
     const currentDir = path.dirname(fileURLToPath(import.meta.url))
 
     // Try relative paths from current file structure (packages/mcp/src/utils/ or dist/utils/)
+    const pathDist = path.resolve(currentDir, './api-full.txt')
     const path1 = path.resolve(currentDir, '../../../api-full.txt')
     const path2 = path.resolve(currentDir, '../../api-full.txt')
     const path3 = path.resolve(currentDir, '../../../../api-full.txt')
 
-    let txtPath = path1
-    if (existsSync(path1)) {
+    let txtPath = pathDist
+    if (existsSync(pathDist)) {
+      txtPath = pathDist
+    } else if (existsSync(path1)) {
       txtPath = path1
     } else if (existsSync(path2)) {
       txtPath = path2

--- a/packages/mcp/src/context/api-context.ts
+++ b/packages/mcp/src/context/api-context.ts
@@ -1,14 +1,1 @@
-import { readFileSync, existsSync } from 'fs'
-import path from 'path'
-import { fileURLToPath } from 'url'
-
-const __filename = fileURLToPath(import.meta.url)
-const __dirname = path.dirname(__filename)
-
-// Dynamically handle both bundled dist/ and source src/context/ contexts
-let apiPath = path.resolve(__dirname, '../../../api-full.txt')
-if (!existsSync(apiPath)) {
-  apiPath = path.resolve(__dirname, '../../../../api-full.txt')
-}
-
-export const apiContext = readFileSync(apiPath, 'utf8')
+export const apiContext = ''

--- a/packages/mcp/src/server.ts
+++ b/packages/mcp/src/server.ts
@@ -6,7 +6,6 @@ import {
 } from '@modelcontextprotocol/sdk/types.js'
 
 import type { MCPResponse } from './types.js'
-import { apiContext } from './context/api-context.js'
 import {
   listComponents,
   getManifest,
@@ -374,7 +373,6 @@ server.setRequestHandler(CallToolRequestSchema, async (request) => {
 
 async function start() {
   console.error('API loaded')
-  console.error(apiContext.length)
   const transport = new StdioServerTransport()
   await server.connect(transport)
   console.error('Ignix MCP started')


### PR DESCRIPTION
### **PR Title**
`fix(mcp,engine): resolve filesystem launch crash and copy api-full.txt`

---

### **PR Description**

#### **What does this PR do?**
1. **Resolves Startup Crash**: Removes the unused `apiContext` filesystem check in the MCP server (`packages/mcp/src/server.ts`) and empties `api-context.ts`. This resolves the `ENOENT: no such file or directory` crash when starting the server globally.
2. **Fixes Silent NLP Intent Bug**: Configures the engine (`packages/engine/package.json`) to copy `api-full.txt` into its `dist/` directory at build time, ensuring the NLP exact matching functions correctly in production.


#### **Type of Change**
- [x] 🐛 Bug fix (MCP crash and Engine intent parser)
- [x] 🔧 Configuration or CI/CD change

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

**MCP Server Changes:**
- Removed `apiContext` import and reference from `packages/mcp/src/server.ts` to resolve startup ENOENT error
- Converted `packages/mcp/src/context/api-context.ts` to export empty string constant instead of reading file at runtime

**Bug Fixes:**
- Fixed MCP server crash when starting globally due to missing `api-context.ts` file check
- Fixed NLP intent parser in production by ensuring `api-full.txt` is copied to dist directory during build

**Tooling / Config / CI Changes:**
- Updated `packages/engine/package.json` build scripts to copy `src/manifests/*.json` and `api-full.txt` to dist during build
- Modified `build` script to include file copying before `build:index`
- Updated `dev` script to include copy steps after `tsup --watch`

**Breaking Changes:**
- `apiContext` export in `packages/mcp/src/context/api-context.ts` is now an empty string instead of containing file contents

<!-- end of auto-generated comment: release notes by coderabbit.ai -->