### PR TITLE
Release from Development

### DIFF
--- a/packages/engine/package.json
+++ b/packages/engine/package.json
@@ -12,9 +12,9 @@
         }
     },
     "scripts": {
-        "build": "tsup && copyfiles -u 2 src/manifests/*.json dist/manifests && pnpm build:index",
+        "build": "tsup && copyfiles -u 2 src/manifests/*.json dist/manifests && copyfiles -f ../../api-full.txt dist && pnpm build:index",
         "build:index": "tsx src/tools/build-index.ts",
-        "dev": "tsup --watch --onSuccess \"copyfiles -u 2 src/manifests/*.json dist/manifests && pnpm build:index\""
+        "dev": "tsup --watch --onSuccess \"copyfiles -u 2 src/manifests/*.json dist/manifests && copyfiles -f ../../api-full.txt dist && pnpm build:index\""
     },
     "dependencies": {
         "emmet": "^2.4.11",

--- a/packages/engine/src/utils/intent-parser.ts
+++ b/packages/engine/src/utils/intent-parser.ts
@@ -68,18 +68,20 @@ function parseIntents(raw: string): IntentEntry[] {
   return entries
 }
 
-// ---- Resolve the api-full.txt path relative to this package root ----
 function loadIntents(): IntentEntry[] {
   try {
     const currentDir = path.dirname(fileURLToPath(import.meta.url))
 
     // Try relative paths from current file structure (packages/mcp/src/utils/ or dist/utils/)
+    const pathDist = path.resolve(currentDir, './api-full.txt')
     const path1 = path.resolve(currentDir, '../../../api-full.txt')
     const path2 = path.resolve(currentDir, '../../api-full.txt')
     const path3 = path.resolve(currentDir, '../../../../api-full.txt')
 
-    let txtPath = path1
-    if (existsSync(path1)) {
+    let txtPath = pathDist
+    if (existsSync(pathDist)) {
+      txtPath = pathDist
+    } else if (existsSync(path1)) {
       txtPath = path1
     } else if (existsSync(path2)) {
       txtPath = path2

--- a/packages/mcp/src/context/api-context.ts
+++ b/packages/mcp/src/context/api-context.ts
@@ -1,14 +1,1 @@
-import { readFileSync, existsSync } from 'fs'
-import path from 'path'
-import { fileURLToPath } from 'url'
-
-const __filename = fileURLToPath(import.meta.url)
-const __dirname = path.dirname(__filename)
-
-// Dynamically handle both bundled dist/ and source src/context/ contexts
-let apiPath = path.resolve(__dirname, '../../../api-full.txt')
-if (!existsSync(apiPath)) {
-  apiPath = path.resolve(__dirname, '../../../../api-full.txt')
-}
-
-export const apiContext = readFileSync(apiPath, 'utf8')
+export const apiContext = ''

--- a/packages/mcp/src/server.ts
+++ b/packages/mcp/src/server.ts
@@ -6,7 +6,6 @@ import {
 } from '@modelcontextprotocol/sdk/types.js'
 
 import type { MCPResponse } from './types.js'
-import { apiContext } from './context/api-context.js'
 import {
   listComponents,
   getManifest,
@@ -374,7 +373,6 @@ server.setRequestHandler(CallToolRequestSchema, async (request) => {
 
 async function start() {
   console.error('API loaded')
-  console.error(apiContext.length)
   const transport = new StdioServerTransport()
   await server.connect(transport)
   console.error('Ignix MCP started')


### PR DESCRIPTION
## Pull Request Title

**Provide a brief title that describes your changes (e.g., "Add feature X" or "Fix issue #123").**

---

## Description

### What does this PR do?

_Provide a concise summary of your changes and what issue or feature they address._

### Related Issues

_Link any related issue(s) with references to help reviewers understand the context._

- Closes #ISSUE_NUMBER (if applicable)

## Type of Change

- [x] 🐛 Bug fix
- [ ] 🚀 New feature
- [ ] 📄 Documentation update
- [ ] ⚙️ Code refactoring
- [ ] 🔧 Configuration or CI/CD change
- [ ] 🧹 Maintenance or dependency update

## Checklist

_Please ensure the following have been completed before submitting:_

- [ ] I have linted my code using `npm run lint`.
- [ ] I have updated the documentation as needed.
- [ ] I have added or updated tests for the changes in this PR.
- [ ] I have verified that my changes work in all supported environments (e.g., Chrome, Firefox, Safari).

## Screenshots (if applicable)

_Provide screenshots or GIFs if this PR changes the UI or has visible results._

## Additional Context

_Include any other context, references, or information that may be useful for the reviewers._

---

### Thank you for your contribution!

_We appreciate your efforts in making this project better._


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## MCP server changes
- Removed `apiContext` initialization logic from `packages/mcp/src/context/api-context.ts`, changing it from dynamically loading `api-full.txt` at module load time to hardcoding an empty string
- Removed `apiContext` import and related logging from `packages/mcp/src/server.ts`

## Bug fixes
- Fixed filesystem path resolution for `api-full.txt` in the engine module by updating `loadIntents()` in `packages/engine/src/utils/intent-parser.ts` to check for a local copy first (via `./api-full.txt`) before falling back to other relative paths
- Resolved build-time availability of `api-full.txt` by copying it into the `dist` directory during both the `build` and `dev` watch pipelines

## Tooling / config / CI changes
- Updated `packages/engine/package.json` build and dev scripts to copy `../../api-full.txt` into `dist` as part of the `build` pipeline and the `dev` watch `--onSuccess` pipeline

## Breaking changes
None

<!-- end of auto-generated comment: release notes by coderabbit.ai -->