### PR TITLE
fix(release): publish npm-safe workspace dependencies

### DIFF
--- a/.github/changeset-version.mjs
+++ b/.github/changeset-version.mjs
@@ -1,9 +1,8 @@
-/* eslint-disable @typescript-eslint/no-unused-vars */
 /* eslint-disable no-undef */
 // ORIGINALLY FROM CLOUDFLARE WRANGLER:
 // https://github.com/cloudflare/wrangler2/blob/main/.github/changeset-version.js
 
-import { exec } from 'child_process';
+import { execFileSync } from 'child_process';
 
 // This script is used by the `changeset.yml` workflow to update the version of the packages being released.
 // The standard step is only to run `changeset version` but this does not update the pnpm-lock.yaml file.
@@ -11,19 +10,13 @@ import { exec } from 'child_process';
 // This is a workaround until this is handled automatically by `changeset version`.
 // See https://github.com/changesets/changesets/issues/421.
 console.log('Running changeset version...');
-exec('npx changeset version', (error, stdout, stderr) => {
-  if (error) {
-    console.error('Error running changeset version:', error);
-    process.exit(1);
-  }
-  console.log(' Changeset version completed');
-
-  console.log('Running pnpm install to update lockfile...');
-  exec('pnpm install --no-frozen-lockfile', (error, stdout, stderr) => {
-    if (error) {
-      console.error('Error running pnpm install:', error);
-      process.exit(1);
-    }
-    console.log('pnpm install completed');
-  });
+execFileSync('pnpm', ['exec', 'changeset', 'version'], {
+  stdio: 'inherit',
 });
+console.log('Changeset version completed');
+
+console.log('Running pnpm install to update lockfile...');
+execFileSync('pnpm', ['install', '--no-frozen-lockfile'], {
+  stdio: 'inherit',
+});
+console.log('pnpm install completed');

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -58,7 +58,7 @@ jobs:
           commit: "chore(release): version packages"
           title: "chore(release): version packages"
           version: node .github/changeset-version.mjs
-          publish: node scripts/resolve-workspace-deps.mjs && pnpm changeset publish --no-git-checks
+          publish: node scripts/resolve-workspace-deps.mjs && pnpm exec changeset publish --no-git-checks
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           NPM_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/scripts/resolve-workspace-deps.mjs
+++ b/scripts/resolve-workspace-deps.mjs
@@ -4,11 +4,15 @@ import { join } from 'path';
 const pkgDirs = readdirSync('packages').map(d => join('packages', d));
 
 const versions = {};
+const publishablePackages = new Map();
 for (const dir of pkgDirs) {
   const pkgPath = join(dir, 'package.json');
   if (!existsSync(pkgPath)) continue;
   const pkg = JSON.parse(readFileSync(pkgPath, 'utf8'));
   versions[pkg.name] = pkg.version;
+  if (!pkg.private) {
+    publishablePackages.set(pkgPath, pkg.name);
+  }
 }
 
 for (const dir of pkgDirs) {
@@ -29,4 +33,25 @@ for (const dir of pkgDirs) {
     writeFileSync(pkgPath, JSON.stringify(pkg, null, 2) + '\n');
     console.log(`Resolved workspace deps in ${pkgPath}`);
   }
+}
+
+const unresolved = [];
+for (const [pkgPath, pkgName] of publishablePackages) {
+  const pkg = JSON.parse(readFileSync(pkgPath, 'utf8'));
+  for (const depType of ['dependencies', 'devDependencies', 'peerDependencies', 'optionalDependencies']) {
+    if (!pkg[depType]) continue;
+    for (const [dep, ver] of Object.entries(pkg[depType])) {
+      if (typeof ver === 'string' && ver.startsWith('workspace:')) {
+        unresolved.push(`${pkgName} -> ${depType}.${dep} (${ver})`);
+      }
+    }
+  }
+}
+
+if (unresolved.length > 0) {
+  console.error('Unresolved workspace dependencies remain:');
+  for (const item of unresolved) {
+    console.error(`- ${item}`);
+  }
+  process.exit(1);
 }


### PR DESCRIPTION
## Pull Request Title

Fix npm release workflow for workspace dependencies

---

## Description

### What does this PR do?

This PR fixes the release workflow so npm packages are published with valid dependency versions instead of unresolved `workspace:*` references.

Changes include:

- Makes the Changesets version script run synchronously.
- Uses `pnpm exec changeset publish` during release.
- Adds a safety check to fail publishing if any publishable package still contains `workspace:*`.

This should fix the issue where CLI/MCP packages were not updating correctly on npm and global CLI installs failed due to workspace dependency errors.

### Related Issues

- Closes #ISSUE_NUMBER

## Type of Change

- [x] 🐛 Bug fix
- [ ] 🚀 New feature
- [ ] 📄 Documentation update
- [ ] ⚙️ Code refactoring
- [x] 🔧 Configuration or CI/CD change
- [ ] 🧹 Maintenance or dependency update

## Checklist

- [ ] I have linted my code using `npm run lint`.
- [ ] I have updated the documentation as needed.
- [ ] I have added or updated tests for the changes in this PR.
- [ ] I have verified that my changes work in all supported environments.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Tooling / config / CI changes

- **Synchronous version script execution** (`.github/changeset-version.mjs`): Updated to execute `changeset version` and `pnpm install --no-frozen-lockfile` synchronously using `execFileSync` instead of asynchronous callbacks, ensuring proper sequencing during the release workflow.

- **Publishing method update** (`.github/workflows/release.yml`): Changed the Changesets publish command from `pnpm changeset publish` to `pnpm exec changeset publish` to properly resolve workspace dependencies during publication.

- **Workspace dependency validation** (`scripts/resolve-workspace-deps.mjs`): Added safety check that fails the publishing process (exit code 1) if any publishable packages still contain unresolved `workspace:*` references, preventing invalid packages from being released to npm.

## Breaking changes

None

<!-- end of auto-generated comment: release notes by coderabbit.ai -->