### PR TITLE
fix(release): fix the release.yml workflow for release of the package

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -58,7 +58,7 @@ jobs:
           commit: "chore(release): version packages"
           title: "chore(release): version packages"
           version: node .github/changeset-version.mjs
-          publish: node scripts/resolve-workspace-deps.mjs && pnpm exec changeset publish --no-git-checks
+          publish: node scripts/resolve-workspace-deps.mjs && pnpm exec changeset publish
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           NPM_TOKEN: ${{ secrets.NPM_TOKEN }}


### PR DESCRIPTION
## Pull Request Title

Fix Changesets publish command

---

## Description

### What does this PR do?

This PR fixes the release workflow by removing the unsupported `--no-git-checks` flag from the Changesets publish command.

The current command fails with:

```txt
Unknown flag for publish: --git-checks
```

This prevents npm publishing even when the release workflow runs.

### Related Issues

- Closes #ISSUE_NUMBER

## Type of Change

- [x] 🐛 Bug fix
- [ ] 🚀 New feature
- [ ] 📄 Documentation update
- [ ] ⚙️ Code refactoring
- [x] 🔧 Configuration or CI/CD change
- [ ] 🧹 Maintenance or dependency update

## Checklist

- [ ] I have linted my code using `npm run lint`.
- [ ] I have updated the documentation as needed.
- [ ] I have added or updated tests for the changes in this PR.
- [ ] I have verified that my changes work in all supported environments.
