### PR TITLE
fix(cli): fix code rabbit issue

### DIFF
--- a/docs/docs/components/badge.mdx
+++ b/docs/docs/components/badge.mdx
@@ -189,4 +189,4 @@ Ignix Lite badges are built using native HTML elements and semantic attributes f
 |---|---|---|
 | `data-intent` | `'success' \| 'danger' \| 'warning' \| 'neutral'` | Applies semantic badge styles |
 | `role="status"` | `string` | Announces live status information for accessibility |
-| *(text content)* | — | Label displayed inside the badge |
+| *(text content)* | - | Label displayed inside the badge |

--- a/packages/cli/src/commands/agent-docs.ts
+++ b/packages/cli/src/commands/agent-docs.ts
@@ -1,23 +1,20 @@
 import { writeFileSync, mkdirSync, statSync, existsSync } from 'fs'
 import path from 'path'
 import pc from 'picocolors'
+import prompts from 'prompts'
 import { manifests } from '@mindfiredigital/ignix-lite-engine'
 
+export const SUPPORTED_AGENTS = ['cursor', 'claude', 'codex'] as const
+export type SupportedAgent = typeof SUPPORTED_AGENTS[number]
+
 interface AgentDocsOptions {
-  agent: 'cursor' | 'claude' | 'codex'
+  agent: SupportedAgent
   outputPath?: string
+  force?: boolean
 }
 
-export function agentDocsCommand(options: AgentDocsOptions) {
+export async function agentDocsCommand(options: AgentDocsOptions) {
   const agentType = options.agent
-
-  // Validation: Fail fast for unsupported agents
-  const validAgents = ['cursor', 'claude', 'codex']
-  if (!validAgents.includes(agentType)) {
-    console.log(pc.red(`\nError: Unsupported agent type "${agentType}".`))
-    console.log(`Allowed agents are: ${pc.yellow(validAgents.join(', '))}\n`)
-    process.exit(1)
-  }
 
   let fileName = '.cursorrules'
   if (agentType === 'claude') {
@@ -36,11 +33,10 @@ export function agentDocsCommand(options: AgentDocsOptions) {
       if (existsSync(resolvedOutput)) {
         isDir = statSync(resolvedOutput).isDirectory()
       } else {
-        // If directory doesn't exist yet, treat it as a directory if it ends with a slash or has no file extension
+        // Trailing slash (either / or \) explicitly signals directory intent when non-existent
         isDir =
           options.outputPath.endsWith('/') ||
-          options.outputPath.endsWith('\\') ||
-          !path.basename(options.outputPath).includes('.')
+          options.outputPath.endsWith('\\')
       }
     } catch {
       isDir = false
@@ -50,6 +46,21 @@ export function agentDocsCommand(options: AgentDocsOptions) {
       targetPath = path.join(resolvedOutput, fileName)
     } else {
       targetPath = resolvedOutput
+    }
+  }
+
+  // Interactive Overwrite Guard
+  if (existsSync(targetPath) && !options.force) {
+    const response = await prompts({
+      type: 'confirm',
+      name: 'overwrite',
+      message: `File "${path.basename(targetPath)}" already exists at "${targetPath}". Overwrite?`,
+      initial: false
+    })
+
+    if (!response.overwrite) {
+      console.log(pc.yellow('\nGeneration cancelled. Use --force or -f to overwrite.\n'))
+      return
     }
   }
 
@@ -88,6 +99,22 @@ function generateRulesContent(): string {
     content += `* **HTML Tag / Element**: \`<${manifest.element}>\`\n`
     content += `* **Default Emmet**: \`${manifest.emmet}\`\n`
 
+    if (manifest.required_wrapper) {
+      content += `* **Required Parent Wrapper**: \`<${manifest.required_wrapper}>\`\n`
+    }
+
+    if (manifest.required_props && manifest.required_props.length > 0) {
+      content += `* **Required Attributes**: \`${manifest.required_props.join('`, `')}\`\n`
+    }
+
+    if (manifest.forbidden_props && manifest.forbidden_props.length > 0) {
+      content += `* **Forbidden Attributes**: \`${manifest.forbidden_props.join('`, `')}\`\n`
+    }
+
+    if (manifest.required_slots && manifest.required_slots.length > 0) {
+      content += `* **Required Slots**: \`${manifest.required_slots.join('`, `')}\`\n`
+    }
+
     if (manifest.props && Object.keys(manifest.props).length > 0) {
       content += `* **Allowed Attributes**:\n`
       Object.entries(manifest.props).forEach(([propName, propDef]) => {
@@ -106,6 +133,10 @@ function generateRulesContent(): string {
         const reqStr = slotDef.required ? ' (required)' : ''
         content += `  - \`slot="${slotName}"\`${reqStr}\n`
       })
+    }
+
+    if (manifest.methods && manifest.methods.length > 0) {
+      content += `* **Available JavaScript Methods**: \`${manifest.methods.join('()`, `')}()\`\n`
     }
 
     if (manifest.do && manifest.do.length > 0) {

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -1,4 +1,4 @@
-import { Command } from 'commander'
+import { Command, Option } from 'commander'
 import { initCommand } from './commands/init.js'
 import { themeCommand } from './commands/theme.js'
 import { addCommand } from './commands/add.js'
@@ -10,7 +10,7 @@ import { buildCommand } from './commands/build.js'
 import { buildValidatedCommand } from './commands/build-validated.js'
 import { previewCommand } from './commands/preview.js'
 import { mcpSetupCommand, mcpStartCommand } from './commands/mcp.js'
-import { agentDocsCommand } from './commands/agent-docs.js'
+import { agentDocsCommand, SUPPORTED_AGENTS } from './commands/agent-docs.js'
 
 const program = new Command()
 
@@ -63,14 +63,18 @@ program
 program
   .command('agent-docs')
   .description('Generate customized AI agent instruction context files')
-  .option(
-    '-a, --agent <type>',
-    'Target AI assistant type (cursor, claude, codex)',
-    'cursor'
+  .addOption(
+    new Option('-a, --agent <type>', 'Target AI assistant type')
+      .choices([...SUPPORTED_AGENTS])
+      .default('cursor')
   )
   .option(
     '-o, --output-path <path>',
-    'Custom directory or file path to write rules'
+    'Custom directory (must end with slash) or file path to write rules'
+  )
+  .option(
+    '-f, --force',
+    'Overwrite existing agent rules files without confirmation prompt'
   )
   .action(agentDocsCommand)
 


### PR DESCRIPTION
## Description

### What does this PR do?

Fixed code rabbit issue required for fixing the cli package

### Related Issues

_Link any related issue(s) with references to help reviewers understand the context._

- Closes #ISSUE_NUMBER (if applicable)

## Type of Change

- [x] 🐛 Bug fix
- [ ] 🚀 New feature
- [ ] 📄 Documentation update
- [ ] ⚙️ Code refactoring
- [ ] 🔧 Configuration or CI/CD change
- [ ] 🧹 Maintenance or dependency update

## Checklist

_Please ensure the following have been completed before submitting:_

- [ ] I have linted my code using `npm run lint`.
- [ ] I have updated the documentation as needed.
- [ ] I have added or updated tests for the changes in this PR.
- [ ] I have verified that my changes work in all supported environments (e.g., Chrome, Firefox, Safari).

## Screenshots (if applicable)

_Provide screenshots or GIFs if this PR changes the UI or has visible results._

## Additional Context

_Include any other context, references, or information that may be useful for the reviewers._

---

### Thank you for your contribution!

_We appreciate your efforts in making this project better._


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

- **Tooling / config / CI changes**
  - Updated the CLI `agent-docs` command to use a typed `SUPPORTED_AGENTS` list (`cursor`, `claude`, `codex`) and improved option handling.
  - Added `--force` support to overwrite existing generated agent rules files without prompting.
  - Changed output-path handling so directory targets are only inferred from an explicit trailing slash, and added overwrite confirmation for existing files when `--force` is not set.
  - Expanded generated rules content to include additional manifest sections when available (`required_wrapper`, `required_props`, `forbidden_props`, `required_slots`, `methods`).
  - Refactored the CLI entrypoint to wire the new option choices and `--force` flag through Commander.

- **Docs / Storybook updates**
  - Adjusted the `badge` component docs table formatting by replacing an em dash with a hyphen in the `*(text content)*` row.

**Breaking changes**
- None

<!-- end of auto-generated comment: release notes by coderabbit.ai -->